### PR TITLE
Use inbuilt list methods to access elements

### DIFF
--- a/lib/quotes.dart
+++ b/lib/quotes.dart
@@ -14,13 +14,13 @@ class Quotes extends StatefulWidget {
   //Returns first quote
 
   static Quote getFirst() {
-    return new Quote.fromJson(allquotes[0]);
+    return new Quote.fromJson(allquotes.first);
   }
 
   //Returns last quote
 
   static Quote getLast() {
-    return new Quote.fromJson(allquotes[allquotes.length - 1]);
+    return new Quote.fromJson(allquotes.last);
   }
 
   //Returns random quote


### PR DESCRIPTION
Instead of using index number, can we use `first` and `last` inbuilt methods in list. Even though it doesn't change behavior, it makes things a bit more Dart specific